### PR TITLE
Add history replay on redis

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -372,6 +372,16 @@ func (t *RedisTransport) Close() (err error) {
 	return nil
 }
 
+func containsEventID(entries []redis.XMessage, id string) bool {
+	for _, entry := range entries {
+		if eventID, _ := entry.Values["id"].(string); eventID == id {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (t *RedisTransport) dispatchHistory(s *LocalSubscriber) {
 	entries, err := t.client.XRange(context.Background(), t.historyStreamKey, "-", "+").Result()
 	if err != nil {
@@ -384,22 +394,10 @@ func (t *RedisTransport) dispatchHistory(s *LocalSubscriber) {
 	afterLastEventID := s.RequestLastEventID == EarliestLastEventID
 	responseLastEventID := EarliestLastEventID
 
-	// If the requested Last-Event-ID is not "earliest", check if it exists in the stream.
-	// If it has been evicted (due to MAXLEN trimming), replay all available events
-	// rather than silently dispatching nothing.
-	if !afterLastEventID {
-		found := false
-		for _, entry := range entries {
-			if eventID, _ := entry.Values["id"].(string); eventID == s.RequestLastEventID {
-				found = true
-
-				break
-			}
-		}
-
-		if !found {
-			afterLastEventID = true
-		}
+	// If the requested Last-Event-ID has been evicted (due to MAXLEN trimming),
+	// replay all available events rather than silently dispatching nothing.
+	if !afterLastEventID && !containsEventID(entries, s.RequestLastEventID) {
+		afterLastEventID = true
 	}
 
 	for _, entry := range entries {

--- a/redis.go
+++ b/redis.go
@@ -14,9 +14,12 @@ import (
 )
 
 const (
-	lastEventIDKey = "lastEventID"
-	publishScript  = `
+	lastEventIDKey      = "lastEventID"
+	defaultHistorySize  = 1000
+	historyStreamSuffix = ":history"
+	publishScript       = `
 		redis.call("SET", KEYS[1], ARGV[1])
+		redis.call("XADD", KEYS[2], "MAXLEN", "~", ARGV[4], "*", "id", ARGV[1], "payload", ARGV[3])
 		redis.call("PUBLISH", ARGV[2], ARGV[3])
 		return true
 	`
@@ -27,13 +30,14 @@ var errAuthFailed = errors.New("AUTH failed")
 type RedisTransport struct {
 	sync.RWMutex
 
-	logger        Logger
-	client        *redis.Client
-	subscribers   *SubscriberList
-	closed        chan any
-	publishScript *redis.Script
-	closedOnce    sync.Once
-	redisChannel  string
+	logger           Logger
+	client           *redis.Client
+	subscribers      *SubscriberList
+	closed           chan any
+	publishScript    *redis.Script
+	closedOnce       sync.Once
+	redisChannel     string
+	historyStreamKey string
 }
 
 // RedisConfig holds configuration for Redis connection.
@@ -221,12 +225,13 @@ func NewRedisTransportInstance(
 	subscribeCtx, subscribeCancel := context.WithCancel(context.Background())
 
 	transport := &RedisTransport{
-		logger:        logger,
-		client:        client,
-		subscribers:   NewSubscriberList(subscribersSize),
-		publishScript: redis.NewScript(publishScript),
-		closed:        make(chan any),
-		redisChannel:  redisChannel,
+		logger:           logger,
+		client:           client,
+		subscribers:      NewSubscriberList(subscribersSize),
+		publishScript:    redis.NewScript(publishScript),
+		closed:           make(chan any),
+		redisChannel:     redisChannel,
+		historyStreamKey: redisChannel + historyStreamSuffix,
 	}
 
 	go func() {
@@ -281,8 +286,8 @@ func (t *RedisTransport) Dispatch(update *Update) error {
 
 	AssignUUID(update)
 
-	keys := []string{lastEventIDKey}
-	arguments := []interface{}{update.ID, t.redisChannel, update}
+	keys := []string{lastEventIDKey, t.historyStreamKey}
+	arguments := []interface{}{update.ID, t.redisChannel, update, defaultHistorySize}
 
 	_, err := t.publishScript.Run(context.Background(), t.client, keys, arguments...).Result()
 	if err != nil {
@@ -304,7 +309,7 @@ func (t *RedisTransport) AddSubscriber(s *LocalSubscriber) error {
 	t.Unlock()
 
 	if s.RequestLastEventID != "" {
-		s.HistoryDispatched(EarliestLastEventID)
+		t.dispatchHistory(s)
 	}
 
 	s.Ready()
@@ -365,6 +370,56 @@ func (t *RedisTransport) Close() (err error) {
 	})
 
 	return nil
+}
+
+func (t *RedisTransport) dispatchHistory(s *LocalSubscriber) {
+	entries, err := t.client.XRange(context.Background(), t.historyStreamKey, "-", "+").Result()
+	if err != nil {
+		t.logger.Error("failed to read history stream", zap.Error(err))
+		s.HistoryDispatched(EarliestLastEventID)
+
+		return
+	}
+
+	afterLastEventID := s.RequestLastEventID == EarliestLastEventID
+	responseLastEventID := EarliestLastEventID
+
+	for _, entry := range entries {
+		eventID, _ := entry.Values["id"].(string)
+
+		if !afterLastEventID {
+			responseLastEventID = eventID
+			if eventID == s.RequestLastEventID {
+				afterLastEventID = true
+			}
+
+			continue
+		}
+
+		payload, ok := entry.Values["payload"].(string)
+		if !ok {
+			continue
+		}
+
+		var update Update
+		if err := json.Unmarshal([]byte(payload), &update); err != nil {
+			t.logger.Error("failed to unmarshal history entry", zap.Error(err))
+
+			continue
+		}
+
+		if s.Match(&update) {
+			if !s.Dispatch(&update, true) {
+				s.HistoryDispatched(responseLastEventID)
+
+				return
+			}
+		}
+
+		responseLastEventID = eventID
+	}
+
+	s.HistoryDispatched(responseLastEventID)
 }
 
 func (t *RedisTransport) subscribe(ctx context.Context, cancel context.CancelFunc, subscriber *redis.PubSub) {

--- a/redis.go
+++ b/redis.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	lastEventIDKey      = "lastEventID"
-	defaultHistorySize  = 1000
+	defaultHistorySize  = 20
 	historyStreamSuffix = ":history"
 	publishScript       = `
 		redis.call("SET", KEYS[1], ARGV[1])

--- a/redis.go
+++ b/redis.go
@@ -384,6 +384,24 @@ func (t *RedisTransport) dispatchHistory(s *LocalSubscriber) {
 	afterLastEventID := s.RequestLastEventID == EarliestLastEventID
 	responseLastEventID := EarliestLastEventID
 
+	// If the requested Last-Event-ID is not "earliest", check if it exists in the stream.
+	// If it has been evicted (due to MAXLEN trimming), replay all available events
+	// rather than silently dispatching nothing.
+	if !afterLastEventID {
+		found := false
+		for _, entry := range entries {
+			if eventID, _ := entry.Values["id"].(string); eventID == s.RequestLastEventID {
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			afterLastEventID = true
+		}
+	}
+
 	for _, entry := range entries {
 		eventID, _ := entry.Values["id"].(string)
 

--- a/redis_test.go
+++ b/redis_test.go
@@ -110,6 +110,32 @@ func TestRedisHistoryReplay(t *testing.T) {
 	assert.Equal(t, "event-b", received.Data, "subscriber should receive the missed event from history")
 }
 
+func TestRedisHistoryReplayEvictedID(t *testing.T) {
+	transport := initialize()
+	defer transport.Close()
+
+	topics := []string{"https://topics.local/topic"}
+
+	// Publish events while subscriber is disconnected
+	eventA := &Update{Topics: topics, Event: Event{Data: "event-a"}}
+	require.NoError(t, transport.Dispatch(eventA))
+
+	eventB := &Update{Topics: topics, Event: Event{Data: "event-b"}}
+	require.NoError(t, transport.Dispatch(eventB))
+
+	// Subscriber reconnects with a Last-Event-ID that has been evicted from the stream
+	subscriber := NewLocalSubscriber("urn:uuid:evicted-id", transport.logger, &TopicSelectorStore{})
+	subscriber.SetTopics(topics, nil)
+	require.NoError(t, transport.AddSubscriber(subscriber))
+
+	// Should receive all available events since the requested ID was not found
+	received1 := <-subscriber.Receive()
+	assert.Equal(t, "event-a", received1.Data, "should receive first available event when Last-Event-ID is evicted")
+
+	received2 := <-subscriber.Receive()
+	assert.Equal(t, "event-b", received2.Data, "should receive second available event when Last-Event-ID is evicted")
+}
+
 func TestRedisConcurrent(t *testing.T) {
 	transport1 := initialize()
 	transport2 := initialize()

--- a/redis_test.go
+++ b/redis_test.go
@@ -1,6 +1,7 @@
 package mercure
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -18,6 +19,9 @@ const (
 
 func initialize() *RedisTransport {
 	transport, _ := NewRedisTransport(zap.NewNop(), redisHost, "", "", redisSubscriberSize, redisChannel)
+
+	// Flush leftover data from previous tests to ensure clean state
+	transport.client.FlushDB(context.Background())
 
 	return transport
 }

--- a/redis_test.go
+++ b/redis_test.go
@@ -86,6 +86,30 @@ func TestRedisClose(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestRedisHistoryReplay(t *testing.T) {
+	transport := initialize()
+	defer transport.Close()
+
+	topics := []string{"https://topics.local/topic"}
+
+	// Publish event A — the subscriber's "last seen" event
+	eventA := &Update{Topics: topics, Event: Event{Data: "event-a"}}
+	require.NoError(t, transport.Dispatch(eventA))
+
+	// Publish event B — subscriber is disconnected and misses this
+	eventB := &Update{Topics: topics, Event: Event{Data: "event-b"}}
+	require.NoError(t, transport.Dispatch(eventB))
+
+	// Subscriber reconnects with Last-Event-ID = eventA.ID
+	subscriber := NewLocalSubscriber(eventA.ID, transport.logger, &TopicSelectorStore{})
+	subscriber.SetTopics(topics, nil)
+	require.NoError(t, transport.AddSubscriber(subscriber))
+
+	// Should receive event B from history replay
+	received := <-subscriber.Receive()
+	assert.Equal(t, "event-b", received.Data, "subscriber should receive the missed event from history")
+}
+
 func TestRedisConcurrent(t *testing.T) {
 	transport1 := initialize()
 	transport2 := initialize()


### PR DESCRIPTION
## Summary

  - Implement event history replay for the Redis transport using Redis Streams, enabling subscribers to receive missed events when reconnecting with a Last-Event-ID
  - Previously, the Redis transport called HistoryDispatched(EarliestLastEventID) which effectively skipped history — now it stores and replays events from a capped Redis Stream

## Changes

  Publish-side (Dispatch):
  - Extended the Lua publish script to atomically XADD each event to a <channel>:history Redis Stream alongside the existing SET + PUBLISH
  - The stream is capped at ~20 entries via MAXLEN ~ 20 to bound memory usage

## Subscribe-side (AddSubscriber):
  - Added dispatchHistory() which reads the full history stream via XRANGE, finds the subscriber's Last-Event-ID, and replays all subsequent matching events
  - Handles edge cases: EarliestLastEventID replays everything, unknown IDs gracefully degrade, and topic filtering is respected

## Tests:
  - Added TestRedisHistoryReplay — publishes two events, creates a subscriber with Last-Event-ID set to the first event, and asserts the second event is received via history
  replay